### PR TITLE
Added Handling of Serilog DictionaryValue to sink

### DIFF
--- a/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSink.cs
+++ b/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSink.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Google.Api;
 using Google.Cloud.Logging.Type;
@@ -93,6 +94,15 @@ namespace Serilog.Sinks.GoogleCloudLogging
                                 dict[property.Key + "." + childProperty.Name] = childProperty.Value;
 
                             WriteProperties(entry, dict);
+                            break;
+                        }
+                    case DictionaryValue dictionary when dictionary.Elements.Count > 0:
+                        {
+                            WriteProperties(entry, dictionary.Elements
+                                .ToDictionary(k => property.Key + "."
+                                    + k.Key.ToString().Replace("\"", string.Empty) // remove " surrounding child keys
+                                    , v => v.Value));
+
                             break;
                         }
                 }

--- a/src/TestWeb/HomeController.cs
+++ b/src/TestWeb/HomeController.cs
@@ -24,7 +24,9 @@ namespace TestWeb
             _logger.LogInformation("Testing info message with ILogger abstraction");
             _logger.LogDebug("Testing debug message with ILogger abstraction");
             _logger.LogDebug(eventId: new Random().Next(), message: "Testing message with random event ID");
-            
+            _logger.LogInformation("Test message with a Dictionary {myDict}", new Dictionary<string, string> { { "myKey", "myValue" },
+                { "mySecondKey", "withAValue" } });
+
             // ASP.NET Logger Factor accepts string log names, but these must follow the rules for Google Cloud logging:
             // https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry
             // Names must only include upper and lower case alphanumeric characters, forward-slash, underscore, hyphen, and period. No spaces!


### PR DESCRIPTION
DictionaryValue are not currently handled but is handy if you want to log a structured object. In my case I wanted to log http headers as key->value so I may filter on them.

This PR contains a logging implementation for DictionaryValue + an example usage in TestWeb.

<img width="787" alt="screen shot 2017-12-08 at 10 12 07" src="https://user-images.githubusercontent.com/61634/33758847-59dd202e-dc00-11e7-82d2-b64a68458139.png">