### PR TITLE
Write OriginalFormat property if option is passed in

### DIFF
--- a/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSinkExtensions.cs
+++ b/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSinkExtensions.cs
@@ -44,7 +44,8 @@ namespace Serilog.Sinks.GoogleCloudLogging
             string serviceVersion = null,
             int? batchSizeLimit = null,
             TimeSpan? period = null,
-            string outputTemplate = null
+            string outputTemplate = null,
+            bool writeOriginalFormat = false
         )
         {
             var options = new GoogleCloudLoggingSinkOptions(
@@ -57,7 +58,8 @@ namespace Serilog.Sinks.GoogleCloudLogging
                 useJsonOutput,
                 googleCredentialJson,
                 serviceName,
-                serviceVersion
+                serviceVersion,
+                writeOriginalFormat
             );
 
             return loggerConfiguration.GoogleCloudLogging(options, batchSizeLimit, period, outputTemplate);

--- a/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSinkOptions.cs
+++ b/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSinkOptions.cs
@@ -60,6 +60,13 @@ namespace Serilog.Sinks.GoogleCloudLogging
         public string ServiceVersion { get; set; }
 
         /// <summary>
+        /// Logs do not normally contain a property representing the raw message template string itself.
+        /// Enabling this option adds a property named "OriginalFormat" to the log entry, which can be used in various filtering criteria.
+        /// Defaults to false.
+        /// </summary>
+        public bool WriteOriginalFormat { get; set; }
+
+        /// <summary>
         /// Options for Google Cloud Logging
         /// </summary>
         /// <param name="projectId">ID (not name) of Google Cloud project where logs will be sent.</param>
@@ -72,6 +79,7 @@ namespace Serilog.Sinks.GoogleCloudLogging
         /// <param name="googleCredentialJson">JSON string of Google Cloud credentials file, otherwise will use Application Default credentials found on host by default.</param>
         /// <param name="serviceName">Name of service, added as "serviceContext.service" metadata.</param>
         /// <param name="serviceVersion">Version of service, added as "serviceContext.version" metadata.</param>
+        /// <param name="writeOriginalFormat">Should an additional property be added that contains the original message format string.</param>
         public GoogleCloudLoggingSinkOptions(
             string projectId = null,
             string resourceType = null,
@@ -82,7 +90,8 @@ namespace Serilog.Sinks.GoogleCloudLogging
             bool useJsonOutput = false,
             string googleCredentialJson = null,
             string serviceName = null,
-            string serviceVersion = null
+            string serviceVersion = null,
+            bool writeOriginalFormat = false
         )
         {
             ProjectId = projectId;
@@ -102,6 +111,7 @@ namespace Serilog.Sinks.GoogleCloudLogging
             GoogleCredentialJson = googleCredentialJson;
             ServiceName = serviceName;
             ServiceVersion = serviceVersion ?? "<Unknown>";
+            writeOriginalFormat = writeOriginalFormat;
         }
     }
 }

--- a/src/TestWeb/Program.cs
+++ b/src/TestWeb/Program.cs
@@ -41,8 +41,9 @@ namespace TestWeb
             {
                 ResourceType = "k8s_cluster",
                 LogName = "someLogName",
-                UseSourceContextAsLogName = false,
-                UseJsonOutput = true
+                UseSourceContextAsLogName = true,
+                UseJsonOutput = true,
+                WriteOriginalFormat = true
             };
 
             Log.Logger = new LoggerConfiguration()

--- a/src/TestWeb/appsettings.json
+++ b/src/TestWeb/appsettings.json
@@ -16,8 +16,8 @@
             "someResourceLabel": "bar"
           },
           "useSourceContextAsLogName": true,
-          "useJsonOutput": false,
-          "GoogleCredentialJson": "asdfasdf"
+          "useJsonOutput": true,
+          "writeOriginalFormat": true
         }
       }
     ]


### PR DESCRIPTION
Closes #23 by conditionally writing the OriginalFormat property.  I chose this name to stay aligned with what the Microsoft.Extensions.Logging infrastructure does, otherwise you'd end up with 'duplicate' properties in the payload.

Alternatively, I could configure an enricher and flow the additional property through that way, which sounds appealing.