### PR TITLE
Initialise MonitoredResource from platform if available

### DIFF
--- a/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSink.cs
+++ b/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSink.cs
@@ -44,7 +44,6 @@ namespace Serilog.Sinks.GoogleCloudLogging
             }
 
             _sinkOptions = sinkOptions;
-            _logFormatter = new LogFormatter(_sinkOptions, messageTemplateTextFormatter);
 
             var platform = Platform.Instance();
 
@@ -52,10 +51,13 @@ namespace Serilog.Sinks.GoogleCloudLogging
                 ? new MonitoredResource { Type = sinkOptions.ResourceType }
                 : MonitoredResourceBuilder.FromPlatform(platform);
 
+            var projectId = _sinkOptions.ProjectId ?? _resource.Labels["project_id"];
+            _logFormatter = new LogFormatter(projectId, _sinkOptions.UseSourceContextAsLogName, messageTemplateTextFormatter);
+
             foreach (var kvp in _sinkOptions.ResourceLabels)
                 _resource.Labels[kvp.Key] = kvp.Value;
 
-            var ln = new LogName(sinkOptions.ProjectId, sinkOptions.LogName);
+            var ln = new LogName(projectId, sinkOptions.LogName);
             _logName = ln.ToString();
             _logNameToWrite = LogNameOneof.From(ln);
 

--- a/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSink.cs
+++ b/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSink.cs
@@ -4,6 +4,8 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Google.Api;
+using Google.Api.Gax;
+using Google.Api.Gax.Grpc;
 using Google.Apis.Auth.OAuth2;
 using Google.Cloud.Logging.Type;
 using Google.Cloud.Logging.V2;
@@ -44,7 +46,12 @@ namespace Serilog.Sinks.GoogleCloudLogging
             _sinkOptions = sinkOptions;
             _logFormatter = new LogFormatter(_sinkOptions, messageTemplateTextFormatter);
 
-            _resource = new MonitoredResource { Type = sinkOptions.ResourceType };
+            var platform = Platform.Instance();
+
+            _resource = platform.Type == PlatformType.Unknown
+                ? new MonitoredResource { Type = sinkOptions.ResourceType }
+                : MonitoredResourceBuilder.FromPlatform(platform);
+
             foreach (var kvp in _sinkOptions.ResourceLabels)
                 _resource.Labels[kvp.Key] = kvp.Value;
 

--- a/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSinkExtensions.cs
+++ b/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSinkExtensions.cs
@@ -32,7 +32,7 @@ namespace Serilog.Sinks.GoogleCloudLogging
         /// </summary>
         public static LoggerConfiguration GoogleCloudLogging(
             this LoggerSinkConfiguration loggerConfiguration,
-            string projectId,
+            string projectId = null,
             string resourceType = null,
             string logName = null,
             Dictionary<string, string> labels = null,

--- a/src/Serilog.Sinks.GoogleCloudLogging/LogFormatter.cs
+++ b/src/Serilog.Sinks.GoogleCloudLogging/LogFormatter.cs
@@ -11,12 +11,14 @@ namespace Serilog.Sinks.GoogleCloudLogging
 {
     internal class LogFormatter
     {
-        private readonly GoogleCloudLoggingSinkOptions _sinkOptions;
+        private readonly string _projectId;
+        private readonly bool _useSourceContextAsLogName;
         private readonly MessageTemplateTextFormatter _messageTemplateTextFormatter;
 
-        public LogFormatter(GoogleCloudLoggingSinkOptions sinkOptions, MessageTemplateTextFormatter messageTemplateTextFormatter)
+        public LogFormatter(string projectId, bool useSourceContextAsLogName, MessageTemplateTextFormatter messageTemplateTextFormatter)
         {
-            _sinkOptions = sinkOptions;
+            _projectId = projectId;
+            _useSourceContextAsLogName = useSourceContextAsLogName;
             _messageTemplateTextFormatter = messageTemplateTextFormatter;
         }
 
@@ -151,8 +153,8 @@ namespace Serilog.Sinks.GoogleCloudLogging
 
         private void CheckIfSourceContext(LogEntry log, string propertyKey, string stringValue)
         {
-            if (_sinkOptions.UseSourceContextAsLogName && propertyKey.Equals("SourceContext", StringComparison.OrdinalIgnoreCase))
-                log.LogName = new LogName(_sinkOptions.ProjectId, stringValue).ToString();
+            if (_useSourceContextAsLogName && propertyKey.Equals("SourceContext", StringComparison.OrdinalIgnoreCase))
+                log.LogName = new LogName(_projectId, stringValue).ToString();
         }
     }
 }


### PR DESCRIPTION
Added automatic resource labels pre-population from Platform instance.
This way we can auto-populate GCE/GKE required labels (e.g. instance-id, zone) without additional calls.
It allows usage of pure JSON configuration as well.