### PR TITLE
allow ResourceType to be set for logging in GCP

### DIFF
--- a/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSink.cs
+++ b/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSink.cs
@@ -46,11 +46,16 @@ namespace Serilog.Sinks.GoogleCloudLogging
             }
 
             // retrieve current environment details (gke/gce/appengine) from google libraries automatically
-            // or fallback to provided option
+            // or fallback to Global resource.
             var platform = Platform.Instance();
+
             _resource = platform.Type == PlatformType.Unknown
-                ? new MonitoredResource { Type = sinkOptions.ResourceType }
+                ? MonitoredResourceBuilder.GlobalResource
                 : MonitoredResourceBuilder.FromPlatform(platform);
+
+            // if ResourceType has been explicitly set then use it.
+            if (sinkOptions.ResourceType != null)
+                _resource.Type = sinkOptions.ResourceType;
 
             foreach (var kvp in _sinkOptions.ResourceLabels)
                 _resource.Labels[kvp.Key] = kvp.Value;

--- a/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSinkOptions.cs
+++ b/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSinkOptions.cs
@@ -12,8 +12,8 @@ namespace Serilog.Sinks.GoogleCloudLogging
         public string ProjectId { get; set; }
 
         /// <summary>
-        /// Resource type for logs.
-        /// Will be automatically identified if running in GCP, otherwise default is "global" which shows as "Global" in Google Cloud Console UI.
+        /// Resource type for logs, one of (https://cloud.google.com/logging/docs/api/v2/resource-list).
+        /// If value not provided then if running in GCP it will be automatically identified, otherwise default is "global" which shows as "Global" in Google Cloud Console UI.
         /// </summary>
         public string ResourceType { get; set; }
 
@@ -90,7 +90,7 @@ namespace Serilog.Sinks.GoogleCloudLogging
         )
         {
             ProjectId = projectId;
-            ResourceType = resourceType ?? "global";
+            ResourceType = resourceType;
             LogName = logName ?? "Default";
 
             if (labels != null)


### PR DESCRIPTION
We run our software on Google Compute Engine.  Prior to v 2.1.0 the sink used to log all messages to the `Global` resource type, but due to the automatic way the sink looks for resource type it now logs it as `gce_instance`.

This PR will allow users to override the default automatic resource type by explicitly setting the value, if they do not set a value then the current defaults will continue to apply.