### PR TITLE
Forward compatible logging client instantiation

### DIFF
--- a/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSink.cs
+++ b/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSink.cs
@@ -40,9 +40,7 @@ namespace Serilog.Sinks.GoogleCloudLogging
             }
             else
             {
-                var googleCredential = GoogleCredential.FromJson(sinkOptions.GoogleCredentialJson);
-                var channel = new Grpc.Core.Channel(LoggingServiceV2Client.DefaultEndpoint.Host, googleCredential.ToChannelCredentials());
-                _client = LoggingServiceV2Client.Create(channel);
+                _client = new LoggingServiceV2ClientBuilder { JsonCredentials = sinkOptions.GoogleCredentialJson }.Build();
             }
 
             // retrieve current environment details (gke/gce/appengine) from google libraries automatically


### PR DESCRIPTION
Using forward compatible and simpler syntax to instantiate logging client in case where explicit JSON creds are supplied.  Inadvertently got myself into Google dependency hell installing their secret manager in the same project as the logger and found this issue during my debugging.