### PR TITLE
Updating to Google.Cloud.Logging.V2 v3.0.0 which no longer supports netstandard1.5

### DIFF
--- a/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSink.cs
+++ b/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSink.cs
@@ -40,9 +40,7 @@ namespace Serilog.Sinks.GoogleCloudLogging
             }
             else
             {
-                var googleCredential = GoogleCredential.FromJson(sinkOptions.GoogleCredentialJson);
-                var channel = new Grpc.Core.Channel(LoggingServiceV2Client.DefaultEndpoint.Host, googleCredential.ToChannelCredentials());
-                _client = LoggingServiceV2Client.Create(channel);
+                _client = new LoggingServiceV2ClientBuilder { JsonCredentials = sinkOptions.GoogleCredentialJson }.Build();
             }
 
             // retrieve current environment details (gke/gce/appengine) from google libraries automatically

--- a/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSink.cs
+++ b/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSink.cs
@@ -73,7 +73,7 @@ namespace Serilog.Sinks.GoogleCloudLogging
                 entries.Add(CreateLogEntry(e, writer));
 
             if (entries.Count > 0)
-                await _client.WriteLogEntriesAsync((LogNameOneof)null, _resource, _sinkOptions.Labels, entries, CancellationToken.None);
+                await _client.WriteLogEntriesAsync((LogName)null, _resource, _sinkOptions.Labels, entries, CancellationToken.None);
         }
 
         private LogEntry CreateLogEntry(LogEvent e, StringWriter writer)

--- a/src/Serilog.Sinks.GoogleCloudLogging/Serilog.Sinks.GoogleCloudLogging.csproj
+++ b/src/Serilog.Sinks.GoogleCloudLogging/Serilog.Sinks.GoogleCloudLogging.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.5;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <LangVersion>8</LangVersion>
     <Description>Serilog sink that writes events to Google Cloud Platform Stackdriver Logging.</Description>
     <Authors>Mani Gandham</Authors>
@@ -16,7 +16,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>2.4.1</Version>
+    <Version>3.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Logging.V2" Version="2.3.0" />
+    <PackageReference Include="Google.Cloud.Logging.V2" Version="3.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
I've got no way around the conflicts with Google.Api.Gax.Grpc v3.0.0's lack of backward compatibility.  In order to use any Google package that targets that version all must.  In my case it's Google.Cloud.SecreManager.V1 which has no older version. I had to update Google.Cloud.Logging.V2 to 3.0.0 in your package to bypass this issue.

Anyway, wouldn't have been a big deal except Google.Cloud.Logging.V2 v3.0.0 no longer supports netstandard1.5.  I removed that target and now everything is working.  I'm guessing you'll want to jump to v3.0.0 (which I already did) since this is a breaking change.  There was one more minor forward compatibility issue I fixed as well.