### PR TITLE
Sink logging level configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.3.0
+- Allow to override minimal logging level configuration property via logging source (using code or `appsettins.json`).
+- Support dynamic level switch for changing the Serilog level at runtime.
+
 ## 3.2.0
 - Bug fix with `IBatchedLogEventSink` implementation.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Serilog.Sinks.GoogleCloudLogging
 
-Serilog sink that writes events to [Google Cloud Platform Stackdriver Logging](https://cloud.google.com/logging/). 
+Serilog sink that writes events to [Google Cloud Platform Stackdriver Logging](https://cloud.google.com/logging/).
 
-Built for `netstandard2.0` 
+Built for `netstandard2.0`
 
 Release notes here: [CHANGELOG.md](CHANGELOG.md)
 
@@ -28,7 +28,7 @@ This requires ['serilog-settings-configuration'](https://github.com/serilog/seri
 ```json
 "Serilog": {
   "Using": [ "Serilog.Sinks.GoogleCloudLogging" ],
-  "MinimumLevel": "Warning",
+  "MinimumLevel": "Information",
   "WriteTo": [
     {
       "Name": "GoogleCloudLogging",
@@ -40,7 +40,8 @@ This requires ['serilog-settings-configuration'](https://github.com/serilog/seri
           "project_id": "PROJECT-ID-HERE-12345",
           "location": "LOCATION-STRING-HERE-region-name",
           "cluster_name": "CLUSTER-NAME-HERE-container-cluster"
-        }
+        },
+        "restrictedToMinimumLevel": "Warning"
       }
     }
   ]
@@ -59,7 +60,7 @@ This library uses the [`Google-Cloud-Dotnet`](https://googleapis.github.io/googl
 
 Name | Default | Description
 ---- | ------- | -----------
-`ProjectId` | | Google Cloud project ID where logs will be sent. Will be automatically set to host project if running in GCP, otherwise required.  
+`ProjectId` | | Google Cloud project ID where logs will be sent. Will be automatically set to host project if running in GCP, otherwise required.
 `ResourceType` | `global` | Resource type for all log output. Will be automatically discovered if running in GCP, otherwise required. Must be one of the supported types listed in the  [cloud logging documentation](https://cloud.google.com/logging/docs/api/v2/resource-list).
 `LogName` | `Default` | Name of the log. This is required if `UseSourceContextAsLogName` is false.
 `Labels` | | `Dictionary<string, string>` of properties added to all log entries.
@@ -74,7 +75,7 @@ Name | Default | Description
 
 Serilog uses structured logging which means each log line is a formatting template with attached properties that are combined to create the final output. When `UseJsonOutput` is false, the output is sent as `TextPayload` to GCP with any properties serialized to string key/value labels.
 
-If `UseJsonOutput` is set to true, the output will be sent as `JsonPayload` to maintain the original data types. This is helpful for querying child properties or numeric values in the Log Viewer, and will also capture property names even if they have null values. 
+If `UseJsonOutput` is set to true, the output will be sent as `JsonPayload` to maintain the original data types. This is helpful for querying child properties or numeric values in the Log Viewer, and will also capture property names even if they have null values.
 
 WARNING: JSON output only accepts numeric values as `double` so all numbers will be converted. Large integers and floating-point values will lose precision. If you want the exact value preserved then log it as a string instead.
 

--- a/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSinkExtensions.cs
+++ b/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSinkExtensions.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using Serilog.Configuration;
+using Serilog.Core;
+using Serilog.Events;
 using Serilog.Formatting.Display;
 using Serilog.Sinks.PeriodicBatching;
 
@@ -8,13 +10,30 @@ namespace Serilog.Sinks.GoogleCloudLogging
 {
     public static class GoogleCloudLoggingSinkExtensions
     {
+        /// <summary>
+        /// Writes log events to Google Cloud Platform Stackdriver Logging.
+        /// </summary>
+        /// <param name="loggerConfiguration">Logger sink configuration.</param>
+        /// <param name="sinkOptions">Google Cloud Logging sink options.</param>
+        /// <param name="batchSizeLimit">The maximum number of events to include in a single batch. The defailt is 100.</param>
+        /// <param name="period">The time to wait between checking for event batches. The default is five seconds.</param>
+        /// <param name="queueLimit">Maximum number of events in the queue. If not specified,
+        /// uses an unbounded queue.</param>
+        /// <param name="outputTemplate">A message template describing the format used to write to the sink .</param>
+        /// <param name="restrictedToMinimumLevel">The minimum level for
+        /// events passed through the sink. Ignored when <paramref name="levelSwitch"/> is specified.</param>
+        /// <param name="levelSwitch">A switch allowing the pass-through minimum level
+        /// to be changed at runtime.</param>
+        /// <returns>Configuration object allowing method chaining.</returns>
         public static LoggerConfiguration GoogleCloudLogging(
             this LoggerSinkConfiguration loggerConfiguration,
             GoogleCloudLoggingSinkOptions sinkOptions,
             int? batchSizeLimit = null,
             TimeSpan? period = null,
             int? queueLimit = null,
-            string outputTemplate = null)
+            string outputTemplate = null,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            LoggingLevelSwitch levelSwitch = null)
         {
             var messageTemplateTextFormatter = String.IsNullOrWhiteSpace(outputTemplate) ? null : new MessageTemplateTextFormatter(outputTemplate, null);
 
@@ -32,13 +51,14 @@ namespace Serilog.Sinks.GoogleCloudLogging
 
             var batchingSink = new PeriodicBatchingSink(sink, batchingOptions);
 
-            return loggerConfiguration.Sink(batchingSink);
+            return loggerConfiguration.Sink(batchingSink, restrictedToMinimumLevel, levelSwitch);
         }
 
         /// <summary>
         /// Overload that accepts all configuration settings as parameters to allow configuration in files using serilog-settings-configuration package.
         /// This method creates a GoogleCloudLoggingSinkOptions and calls the standard constructor above.
         /// </summary>
+        /// <returns>Configuration object allowing method chaining.</returns>
         public static LoggerConfiguration GoogleCloudLogging(
             this LoggerSinkConfiguration loggerConfiguration,
             string projectId = null,
@@ -54,7 +74,9 @@ namespace Serilog.Sinks.GoogleCloudLogging
             int? batchSizeLimit = null,
             TimeSpan? period = null,
             int? queueLimit = null,
-            string outputTemplate = null
+            string outputTemplate = null,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            LoggingLevelSwitch levelSwitch = null
         )
         {
             var options = new GoogleCloudLoggingSinkOptions(
@@ -70,7 +92,8 @@ namespace Serilog.Sinks.GoogleCloudLogging
                 serviceVersion
             );
 
-            return loggerConfiguration.GoogleCloudLogging(options, batchSizeLimit, period, queueLimit, outputTemplate);
+            return loggerConfiguration.GoogleCloudLogging(
+                options, batchSizeLimit, period, queueLimit, outputTemplate, restrictedToMinimumLevel, levelSwitch);
         }
     }
 }


### PR DESCRIPTION
Hello I made the PR. 

Introduced the **restrictedToMinimumLevel** and **levelSwitch** parameters which are very common for Serilog Sinks.

* `restrictedToMinimumLevel` is the minimum level for events passed through the sink. And ignored when `levelSwitch` is specified. It is part of Serilog core logic. Default is `Verbose` and level configured at Serilog configuration level takes precedence. But on the other hand it allows to restrict the logging level up (e.g. global configuration set to log all Verbose and upper log events to File sink, but send to Google Cloud Logging only Warnings and greater).
* `levelSwitch` is a switch allowing the pass-through minimum level to be changed at runtime.

Related:
* [MinimumLevel, LevelSwitches, overrides and dynamic reload](https://github.com/serilog/serilog-settings-configuration#minimumlevel-levelswitches-overrides-and-dynamic-reload)
* [Dynamically changing the Serilog level](https://nblumhardt.com/2014/10/dynamically-changing-the-serilog-level/)
