### PR TITLE
Use Log Correlation

### DIFF
--- a/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSink.cs
+++ b/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSink.cs
@@ -70,7 +70,7 @@ namespace Serilog.Sinks.GoogleCloudLogging
                 entries.Add(CreateLogEntry(e, writer));
 
             if (entries.Count > 0)
-                return _client.WriteLogEntriesAsync((LogName)null, _resource, _sinkOptions.Labels, entries, CancellationToken.None);
+                return _client.WriteLogEntriesAsync((LogName) null, _resource, _sinkOptions.Labels, entries, CancellationToken.None);
 
             return Task.CompletedTask;
         }
@@ -106,9 +106,8 @@ namespace Serilog.Sinks.GoogleCloudLogging
                     entry.JsonPayload.Fields.Add("serviceContext", Value.ForStruct(contextStruct));
                 }
 
-                if (_sinkOptions.UseJsonOutput)
+                if (_sinkOptions.UseLogCorrelation)
                 {
-
                     if (propStruct.Fields.TryGetValue("TraceId", out var traceId))
                     {
                         if (traceId != null && traceId.KindCase == Value.KindOneofCase.StringValue && !string.IsNullOrEmpty(traceId.StringValue))
@@ -128,7 +127,6 @@ namespace Serilog.Sinks.GoogleCloudLogging
                         }
                     }
                 }
-
             }
             else
             {

--- a/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSink.cs
+++ b/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSink.cs
@@ -106,22 +106,26 @@ namespace Serilog.Sinks.GoogleCloudLogging
                     entry.JsonPayload.Fields.Add("serviceContext", Value.ForStruct(contextStruct));
                 }
 
-                if (propStruct.Fields.TryGetValue("TraceId", out var traceId))
+                if (_sinkOptions.UseJsonOutput)
                 {
-                    if (traceId != null && traceId.KindCase == Value.KindOneofCase.StringValue && !string.IsNullOrEmpty(traceId.StringValue))
-                    {
-                        // Maybe we could cache this, but the traceId will change often
-                        entry.Trace = $"projects/{_projectId}/traces/{traceId.StringValue}";
-                        propStruct.Fields.Remove("TraceId");
-                    }
-                }
 
-                if (propStruct.Fields.TryGetValue("SpanId", out var spanId))
-                {
-                    if (spanId != null && traceId.KindCase == Value.KindOneofCase.StringValue && !string.IsNullOrEmpty(spanId.StringValue))
+                    if (propStruct.Fields.TryGetValue("TraceId", out var traceId))
                     {
-                        entry.SpanId = spanId.StringValue;
-                        propStruct.Fields.Remove("SpanId");
+                        if (traceId != null && traceId.KindCase == Value.KindOneofCase.StringValue && !string.IsNullOrEmpty(traceId.StringValue))
+                        {
+                            // Maybe we could cache this, but the traceId will change often
+                            entry.Trace = $"projects/{_projectId}/traces/{traceId.StringValue}";
+                            propStruct.Fields.Remove("TraceId");
+                        }
+                    }
+
+                    if (propStruct.Fields.TryGetValue("SpanId", out var spanId))
+                    {
+                        if (spanId != null && traceId.KindCase == Value.KindOneofCase.StringValue && !string.IsNullOrEmpty(spanId.StringValue))
+                        {
+                            entry.SpanId = spanId.StringValue;
+                            propStruct.Fields.Remove("SpanId");
+                        }
                     }
                 }
 

--- a/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSinkOptions.cs
+++ b/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSinkOptions.cs
@@ -45,6 +45,13 @@ namespace Serilog.Sinks.GoogleCloudLogging
         /// Defaults to false. This must be set to True for logged exceptions to be forwarded to StackDriver Error Reporting.
         /// </summary>
         public bool UseJsonOutput { get; set; }
+        
+        /// <summary>
+        /// Integrate logs with Cloud Trace by setting LogEntry.Trace and LogEntry.SpanId if the LogEvent contains TraceId and SpanId properties.
+        /// Required for Google Cloud Trace Log Correlation.
+        /// See https://cloud.google.com/trace/docs/trace-log-integration
+        /// </summary>
+        public bool UseLogCorrelation { get; set; }
 
         /// <summary>
         /// JSON string of Google Cloud credentials file, otherwise will use Application Default credentials found on host by default.
@@ -64,13 +71,6 @@ namespace Serilog.Sinks.GoogleCloudLogging
         public string ServiceVersion { get; set; }
 
         /// <summary>
-        /// LogEntry.Trace and LogEntry.SpanId are set, if the LogEvent contains TraceId and SpanId properties.
-        /// Required for Google Trace Log Correlation.
-        /// See https://cloud.google.com/trace/docs/trace-log-integration
-        /// </summary>
-        public bool UseLogCorrelation { get; set; }
-
-        /// <summary>
         /// Options for Google Cloud Logging
         /// </summary>
         /// <param name="projectId">ID (not name) of Google Cloud project where logs will be sent.</param>
@@ -80,6 +80,7 @@ namespace Serilog.Sinks.GoogleCloudLogging
         /// <param name="resourceLabels">Additional custom labels for the resource type added to all log entries.</param>
         /// <param name="useSourceContextAsLogName"></param>
         /// <param name="useJsonOutput"></param>
+        /// <param name="useLogCorrelation"></param>
         /// <param name="googleCredentialJson">JSON string of Google Cloud credentials file, otherwise will use Application Default credentials found on host by default.</param>
         /// <param name="serviceName">Name of service, added as "serviceContext.service" metadata.</param>
         /// <param name="serviceVersion">Version of service, added as "serviceContext.version" metadata.</param>
@@ -91,6 +92,7 @@ namespace Serilog.Sinks.GoogleCloudLogging
             Dictionary<string, string> resourceLabels = null,
             bool useSourceContextAsLogName = true,
             bool useJsonOutput = false,
+            bool useLogCorrelation = true,
             string googleCredentialJson = null,
             string serviceName = null,
             string serviceVersion = null
@@ -110,6 +112,7 @@ namespace Serilog.Sinks.GoogleCloudLogging
 
             UseSourceContextAsLogName = useSourceContextAsLogName;
             UseJsonOutput = useJsonOutput;
+            UseLogCorrelation = useLogCorrelation;
             GoogleCredentialJson = googleCredentialJson;
             ServiceName = serviceName;
             ServiceVersion = serviceVersion ?? "<Unknown>";

--- a/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSinkOptions.cs
+++ b/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSinkOptions.cs
@@ -64,6 +64,13 @@ namespace Serilog.Sinks.GoogleCloudLogging
         public string ServiceVersion { get; set; }
 
         /// <summary>
+        /// LogEntry.Trace and LogEntry.SpanId are set, if the LogEvent contains TraceId and SpanId properties.
+        /// Required for Google Trace Log Correlation.
+        /// See https://cloud.google.com/trace/docs/trace-log-integration
+        /// </summary>
+        public bool UseLogCorrelation { get; set; }
+
+        /// <summary>
         /// Options for Google Cloud Logging
         /// </summary>
         /// <param name="projectId">ID (not name) of Google Cloud project where logs will be sent.</param>


### PR DESCRIPTION
Apply Log Correlation as described here: https://cloud.google.com/trace/docs/trace-log-integration

The detail is, TraceId and SpanId are only respected within the google trace viewer, when `LogEntry.Trace` and `LogEntry.SpanId` are set. If they are only in the normal properties, they are stored, but not assigned to the trace itself, so you have manually filter them.

![image](https://user-images.githubusercontent.com/1831942/110716254-15611d00-8207-11eb-9367-a0d39c04aed1.png)
