### PR TITLE
Treat 'TraceSampled' as a special property

### DIFF
--- a/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSink.cs
+++ b/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSink.cs
@@ -127,7 +127,11 @@ namespace Serilog.Sinks.GoogleCloudLogging
             if (_sinkOptions.UseLogCorrelation && key.Equals("SpanId", StringComparison.OrdinalIgnoreCase))
                 log.SpanId = GetString(value);
 
+            if (_sinkOptions.UseLogCorrelation && key.Equals("TraceSampled", StringComparison.OrdinalIgnoreCase))
+                log.TraceSampled = GetBoolean(value);
+
             static string GetString(LogEventPropertyValue v) => (v as ScalarValue)?.Value?.ToString() ?? "";
+            static bool GetBoolean(LogEventPropertyValue v) => (v as ScalarValue)?.Value is true;
         }
 
         private static LogSeverity TranslateSeverity(LogEventLevel level) => level switch


### PR DESCRIPTION
In order for the Cloud Logging / Cloud Trace integration to work as
intended, the TraceSampled property should be set for traces that are
recorded.

![image](https://user-images.githubusercontent.com/1032755/124728265-bccd3280-df0f-11eb-8148-adddfded13e4.png)
