### PR TITLE
Updated Google.Cloud.Logging.V2 version from 3.6.0 to 4.0.0

### DIFF
--- a/src/Serilog.Sinks.GoogleCloudLogging/Serilog.Sinks.GoogleCloudLogging.csproj
+++ b/src/Serilog.Sinks.GoogleCloudLogging/Serilog.Sinks.GoogleCloudLogging.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Logging.V2" Version="3.6.0" />
+    <PackageReference Include="Google.Cloud.Logging.V2" Version="4.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
An update for Google.Cloud.Logging.V2 package from 3.6.0 to 4.0.0 in order to accommodate changes for GAX4 with a new underlying GRPC implementation released by the GCP team in their new libraries.