### PR TITLE
propagates current trace and span ids. Closes #67

### DIFF
--- a/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSink.cs
+++ b/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSink.cs
@@ -104,6 +104,18 @@ public class GoogleCloudLoggingSink : IBatchedLogEventSink
             HandleSpecialProperty(log, property.Key, property.Value);
         }
 
+        if (_sinkOptions.UseLogCorrelation)
+        {
+            if (evnt.TraceId.ToString() is { Length: > 0 } traceId)
+            {
+                log.Trace = $"projects/{_projectId}/traces/{traceId}";
+            }
+            if (evnt.SpanId?.ToString() is { Length: > 0 } spanId)
+            {
+                log.SpanId = spanId;
+            }
+        }
+
         if (_serviceContext != null)
             jsonPayload.Fields.Add("serviceContext", Value.ForStruct(_serviceContext));
 
@@ -119,12 +131,6 @@ public class GoogleCloudLoggingSink : IBatchedLogEventSink
 
         if (_sinkOptions.UseLogCorrelation)
         {
-            if (key.Equals("TraceId", StringComparison.OrdinalIgnoreCase))
-                log.Trace = $"projects/{_projectId}/traces/{GetString(value)}";
-
-            if (key.Equals("SpanId", StringComparison.OrdinalIgnoreCase))
-                log.SpanId = GetString(value);
-
             if (key.Equals("TraceSampled", StringComparison.OrdinalIgnoreCase))
                 log.TraceSampled = GetBoolean(value);
         }

--- a/src/Serilog.Sinks.GoogleCloudLogging/Serilog.Sinks.GoogleCloudLogging.csproj
+++ b/src/Serilog.Sinks.GoogleCloudLogging/Serilog.Sinks.GoogleCloudLogging.csproj
@@ -18,7 +18,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <TargetFrameworks>net6.0;net5.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;netstandard2.1</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -29,14 +29,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Logging.V2" Version="4.0.0" />
+    <PackageReference Include="Google.Cloud.Logging.V2" Version="4.2.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Serilog" Version="2.11.0" />
-    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.3.1" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
+    <PackageReference Include="Serilog" Version="3.1.1" />
+    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="3.1.0" />
+    <PackageReference Condition="'$(TargetFramework)' == 'net6.0'" Include="System.Text.Encodings.Web" Version="6.0.0" />
+    <PackageReference Condition="'$(TargetFramework)' != 'net6.0'" Include="System.Text.Encodings.Web" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/TestWeb/TestWeb.csproj
+++ b/src/TestWeb/TestWeb.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>default</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.11.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
+    <PackageReference Include="Serilog" Version="3.1.1" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Adds a "native" tracing information propagation support by Serilog

For more information, please 

1. https://github.com/serilog/serilog/pull/1955
2. https://github.com/serilog/serilog-aspnetcore/issues/207
3. Release notes to Serilog v3.1.0