### PR TITLE
Fix misspellings of `TraceId`

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ This library uses the [Google Cloud .NET](https://cloud.google.com/dotnet/docs) 
 | ServiceName               | Name of the service added as metadata to log entries. Required for logged exceptions to be forwarded to StackDriver Error Reporting.                                                                                    |
 | ServiceVersion            | Version of the service added as metadata to log entries. Required for logged exceptions to be forwarded to StackDriver Error Reporting.                                                                                 |
 | UseSourceContextAsLogName | The log name for a log entry will be set to the [SourceContext](https://github.com/serilog/serilog/wiki/Writing-Log-Events#source-contexts) property if available. Default is `true`.                                   |
-| UseLogCorrelation         | Integrate logs with [Cloud Trace](https://cloud.google.com/trace) by setting `Trace`, `SpanId`, `TraceSampled` properties if available. Default is `true`.                                                              |
+| UseLogCorrelation         | Integrate logs with [Cloud Trace](https://cloud.google.com/trace) by setting `TraceId`, `SpanId`, `TraceSampled` properties if available. Default is `true`.                                                              |
 | GoogleCredentialJson      | JSON string to override [Application Default Credentials](https://cloud.google.com/docs/authentication/production#providing_credentials_to_your_application) (contents of your credential file).                        |
 
 ### Log Level Mapping

--- a/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSinkOptions.cs
+++ b/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSinkOptions.cs
@@ -39,7 +39,7 @@ public class GoogleCloudLoggingSinkOptions
     public bool UseSourceContextAsLogName { get; set; }
 
     /// <summary>
-    /// Integrate logs with Cloud Trace by setting `Trace`, `SpanId`, `TraceSampled` properties on the LogEvent.
+    /// Integrate logs with Cloud Trace by setting `TraceId`, `SpanId`, `TraceSampled` properties on the LogEvent.
     /// Enabled by default. Required for Google Cloud Trace Log Correlation.
     /// See https://cloud.google.com/trace/docs/trace-log-integration
     /// </summary>


### PR DESCRIPTION
The property is named `TraceId`, not `Trace`. This was documented
incorrectly in two places.