### PR TITLE
Add custom top-level properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ This library uses the [Google Cloud .NET](https://cloud.google.com/dotnet/docs) 
 | UseSourceContextAsLogName | The log name for a log entry will be set to the [SourceContext](https://github.com/serilog/serilog/wiki/Writing-Log-Events#source-contexts) property if available. Default is `true`.                                   |
 | UseLogCorrelation         | Integrate logs with [Cloud Trace](https://cloud.google.com/trace) by setting `Trace`, `SpanId`, `TraceSampled` properties if available. Default is `true`.                                                              |
 | GoogleCredentialJson      | JSON string to override [Application Default Credentials](https://cloud.google.com/docs/authentication/production#providing_credentials_to_your_application) (contents of your credential file).                        |
+| CustomTopLevelPropertyKeys      | Optional names of properties that should be logged on the top-level, next to 'message'.                        |
 
 ### Log Level Mapping
 

--- a/src/Serilog.Sinks.GoogleCloudLogging.Test/GoogleCloudLoggingSinkOptionsTest.cs
+++ b/src/Serilog.Sinks.GoogleCloudLogging.Test/GoogleCloudLoggingSinkOptionsTest.cs
@@ -24,6 +24,7 @@ public class GoogleCloudLoggingSinkOptionsTest
                 ServiceVersion = null,
                 UseSourceContextAsLogName = true,
                 UseLogCorrelation = true,
+                CustomTopLevelPropertyKeys = new string[0]
             });
     }
 
@@ -39,7 +40,8 @@ public class GoogleCloudLoggingSinkOptionsTest
             useLogCorrelation: false,
             googleCredentialJson: "{}",
             serviceName: "service-name",
-            serviceVersion: "1.0.1");
+            serviceVersion: "1.0.1",
+            customTopLevelPropertyKeys: new[] {"foo", "bar"});
 
         options
             .Should()
@@ -54,7 +56,8 @@ public class GoogleCloudLoggingSinkOptionsTest
                 ServiceName = "service-name",
                 ServiceVersion = "1.0.1",
                 UseSourceContextAsLogName = false,
-                UseLogCorrelation = false
+                UseLogCorrelation = false,
+                CustomTopLevelPropertyKeys = new[] {"foo", "bar"}
             });
     }
 

--- a/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSink.cs
+++ b/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSink.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Google.Api;
@@ -96,9 +97,12 @@ public class GoogleCloudLoggingSink : IBatchedLogEventSink
         var jsonPayload = new Struct();
         jsonPayload.Fields.Add("message", Value.ForString(_logFormatter.RenderEventMessage(evnt, writer)));
 
+        foreach (var customTopLevelProperty in GetCustomTopLevelProperties()) 
+            _logFormatter.WritePropertyAsJson(jsonPayload, customTopLevelProperty.Key, customTopLevelProperty.Value);
+
         var propStruct = new Struct();
         jsonPayload.Fields.Add("properties", Value.ForStruct(propStruct));
-        foreach (var property in evnt.Properties)
+        foreach (var property in GetOtherProperties())
         {
             _logFormatter.WritePropertyAsJson(propStruct, property.Key, property.Value);
             HandleSpecialProperty(log, property.Key, property.Value);
@@ -110,6 +114,16 @@ public class GoogleCloudLoggingSink : IBatchedLogEventSink
         log.JsonPayload = jsonPayload;
 
         return log;
+
+        IEnumerable<KeyValuePair<string, LogEventPropertyValue>> GetCustomTopLevelProperties()
+        {
+            return evnt.Properties.Where(p => _sinkOptions.CustomTopLevelPropertyKeys.Any(c => c.Equals(p.Key, StringComparison.OrdinalIgnoreCase)));
+        }
+
+        IEnumerable<KeyValuePair<string, LogEventPropertyValue>> GetOtherProperties()
+        {
+            return evnt.Properties.Where(p => !_sinkOptions.CustomTopLevelPropertyKeys.Any(c => c.Equals(p.Key, StringComparison.OrdinalIgnoreCase)));
+        }
     }
 
     private void HandleSpecialProperty(LogEntry log, string key, LogEventPropertyValue value)

--- a/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSinkExtensions.cs
+++ b/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSinkExtensions.cs
@@ -69,6 +69,7 @@ public static class GoogleCloudLoggingSinkExtensions
         string? googleCredentialJson = null,
         string? serviceName = null,
         string? serviceVersion = null,
+        string[]? customTopLevelPropertyKeys = null,
         int? batchSizeLimit = null,
         TimeSpan? period = null,
         int? queueLimit = null,
@@ -87,7 +88,8 @@ public static class GoogleCloudLoggingSinkExtensions
             useLogCorrelation,
             googleCredentialJson,
             serviceName,
-            serviceVersion
+            serviceVersion,
+            customTopLevelPropertyKeys ?? new string[0]
         );
 
         return loggerConfiguration.GoogleCloudLogging(

--- a/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSinkOptions.cs
+++ b/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSinkOptions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Serilog.Sinks.GoogleCloudLogging;
 
@@ -69,6 +70,11 @@ public class GoogleCloudLoggingSinkOptions
     public string? ServiceVersion { get; set; }
 
     /// <summary>
+    /// Optional names of properties that should be logged on the top-level, next to 'message'.
+    /// </summary>
+    public string[] CustomTopLevelPropertyKeys { get; set; } = new string[0];
+
+    /// <summary>
     /// Options for Google Cloud Logging
     /// </summary>
     /// <param name="projectId">
@@ -105,6 +111,9 @@ public class GoogleCloudLoggingSinkOptions
     /// Attach service version to log entries (added as `serviceContext.version` metadata in `jsonPayload`).
     /// Required for logged exceptions to be forwarded to StackDriver Error Reporting.
     /// </param>
+    /// <param name="customTopLevelPropertyKeys">
+    /// Optional names of properties that should be logged on the top-level, next to 'message'.
+    /// </param>
     public GoogleCloudLoggingSinkOptions(
         string? projectId = null,
         string? resourceType = null,
@@ -115,7 +124,8 @@ public class GoogleCloudLoggingSinkOptions
         bool useLogCorrelation = true,
         string? googleCredentialJson = null,
         string? serviceName = null,
-        string? serviceVersion = null)
+        string? serviceVersion = null,
+        string[]? customTopLevelPropertyKeys = null)
     {
         ProjectId = projectId;
         ResourceType = resourceType;
@@ -134,5 +144,6 @@ public class GoogleCloudLoggingSinkOptions
         GoogleCredentialJson = googleCredentialJson;
         ServiceName = serviceName;
         ServiceVersion = serviceVersion;
+        CustomTopLevelPropertyKeys = customTopLevelPropertyKeys ?? new string[0];
     }
 }

--- a/src/TestWeb/Program.cs
+++ b/src/TestWeb/Program.cs
@@ -38,6 +38,7 @@ try
             ResourceType = "gce_instance",
             LogName = "someLogName",
             UseSourceContextAsLogName = true,
+            CustomTopLevelPropertyKeys = ["customProperty1", "customProperty2"]
         };
 
         builder.Host.UseSerilog((ctx, lc) => lc.WriteTo.Console().WriteTo.GoogleCloudLogging(options).MinimumLevel.Is(LogEventLevel.Verbose));
@@ -76,6 +77,12 @@ try
                 { "valueAsMaxDouble", double.MaxValue },
                 { "valueAsMaxDecimal", decimal.MaxValue },
             });
+        
+        _logger.LogInformation(
+            "Test message with default: {@default} and custom properties: {@customProperty1}, {@customProperty2}", 
+            "default-value",
+            "customProperty1-value",
+            "customProperty2-value");
 
         try
         {

--- a/src/TestWeb/appsettings.json
+++ b/src/TestWeb/appsettings.json
@@ -14,7 +14,8 @@
           },
           "resourceLabels": {
             "someResourceLabel": "bar"
-          }
+          },
+          "customTopLevelPropertyKeys": ["customProperty1", "customProperty2"]
         }
       }
     ]


### PR DESCRIPTION
I'm using your library for almost 2 years now and it's really good!

Recently we had a requirement to push some properties to Google Cloud Logging at one nesting level higher than usually, so directly under the "jsonPayload" node, next to .e.g "message". Current solution doesn't allow for that, so I added another configuration option - CustomTopLevelPropertyKeys - that allows specifying which properties should be added in a top-level. 

To ilustrate, this is how these properties are defined:
![image](https://github.com/manigandham/serilog-sinks-googlecloudlogging/assets/82114/209932e8-af66-4f65-9236-fea07e3f4476)

And here is how the eventual log entry looks like:
![image](https://github.com/manigandham/serilog-sinks-googlecloudlogging/assets/82114/2512d827-6808-4c2b-be72-81626f65abaa)

How about that? 

