### PR TITLE
Upgrades to Serilog 4.0

### DIFF
--- a/src/Serilog.Sinks.GoogleCloudLogging.Benchmark/LogEventEmitBenchmark.cs
+++ b/src/Serilog.Sinks.GoogleCloudLogging.Benchmark/LogEventEmitBenchmark.cs
@@ -1,0 +1,55 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using Serilog.Events;
+using Serilog.Formatting.Json;
+using Serilog.Parsing;
+
+namespace Serilog.Sinks.GoogleCloudLogging.Benchmark;
+
+[MemoryDiagnoser]
+[SimpleJob(runtimeMoniker: RuntimeMoniker.Net90, baseline: false)]
+[SimpleJob(runtimeMoniker: RuntimeMoniker.Net80, baseline: true)]
+public class LogEventEmitBenchmark
+{
+    private readonly GoogleCloudLoggingSink _sink = new("project_test", new JsonFormatter());
+
+    [Benchmark]
+    [ArgumentsSource(nameof(Data))]
+    public void CreateEventsBatch(IReadOnlyCollection<LogEvent> events)
+    {
+        _sink.CreateEventsBatch(events);
+    }
+
+    public IEnumerable<IReadOnlyCollection<LogEvent>> Data()
+    {
+        var timeStamp = DateTimeOffset.UtcNow;
+        var mtParser = new MessageTemplateParser();
+        var mt = mtParser.Parse("Hello {@World}");
+        return
+        [
+            [
+                new LogEvent(timestamp: timeStamp,
+                    level: LogEventLevel.Information,
+                    exception: null,
+                    messageTemplate: mt,
+                    properties: [new LogEventProperty("World", new ScalarValue("Hello World!"))])
+            ],
+            Enumerable.Range(1, 10)
+                .Select(t => new LogEvent(
+                    timestamp: timeStamp.AddMilliseconds(t),
+                    level: LogEventLevel.Information,
+                    exception: null,
+                    messageTemplate: mt,
+                    properties: [new LogEventProperty("World", new ScalarValue("Hello World!"))]))
+                .ToArray(),
+            Enumerable.Range(1, 100)
+                .Select(t => new LogEvent(
+                    timestamp: timeStamp.AddMilliseconds(t),
+                    level: LogEventLevel.Information,
+                    exception: null,
+                    messageTemplate: mt,
+                    properties: [new LogEventProperty("World", new ScalarValue("Hello World!"))]))
+                .ToArray()
+        ];
+    }
+}

--- a/src/Serilog.Sinks.GoogleCloudLogging.Benchmark/LogEventEmitBenchmark.cs
+++ b/src/Serilog.Sinks.GoogleCloudLogging.Benchmark/LogEventEmitBenchmark.cs
@@ -7,6 +7,7 @@ using Serilog.Parsing;
 namespace Serilog.Sinks.GoogleCloudLogging.Benchmark;
 
 [MemoryDiagnoser]
+[SimpleJob(runtimeMoniker: RuntimeMoniker.Net10_0, baseline: false)]
 [SimpleJob(runtimeMoniker: RuntimeMoniker.Net90, baseline: false)]
 [SimpleJob(runtimeMoniker: RuntimeMoniker.Net80, baseline: true)]
 public class LogEventEmitBenchmark

--- a/src/Serilog.Sinks.GoogleCloudLogging.Benchmark/Program.cs
+++ b/src/Serilog.Sinks.GoogleCloudLogging.Benchmark/Program.cs
@@ -1,0 +1,6 @@
+﻿// See https://aka.ms/new-console-template for more information
+
+using BenchmarkDotNet.Running;
+using Serilog.Sinks.GoogleCloudLogging.Benchmark;
+
+_ = BenchmarkRunner.Run<LogEventEmitBenchmark>();

--- a/src/Serilog.Sinks.GoogleCloudLogging.Benchmark/Serilog.Sinks.GoogleCloudLogging.Benchmark.csproj
+++ b/src/Serilog.Sinks.GoogleCloudLogging.Benchmark/Serilog.Sinks.GoogleCloudLogging.Benchmark.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="BenchmarkDotNet" Version="0.15.2" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Serilog.Sinks.GoogleCloudLogging\Serilog.Sinks.GoogleCloudLogging.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Serilog.Sinks.GoogleCloudLogging.Benchmark/Serilog.Sinks.GoogleCloudLogging.Benchmark.csproj
+++ b/src/Serilog.Sinks.GoogleCloudLogging.Benchmark/Serilog.Sinks.GoogleCloudLogging.Benchmark.csproj
@@ -2,13 +2,13 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net9.0;net8.0;net10.0;</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="BenchmarkDotNet" Version="0.15.2" />
+      <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Serilog.Sinks.GoogleCloudLogging.Test/Serilog.Sinks.GoogleCloudLogging.Test.csproj
+++ b/src/Serilog.Sinks.GoogleCloudLogging.Test/Serilog.Sinks.GoogleCloudLogging.Test.csproj
@@ -1,20 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>default</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="FluentAssertions" Version="7.2.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Serilog.Sinks.GoogleCloudLogging.sln
+++ b/src/Serilog.Sinks.GoogleCloudLogging.sln
@@ -9,6 +9,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestWeb", "TestWeb\TestWeb.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Serilog.Sinks.GoogleCloudLogging.Test", "Serilog.Sinks.GoogleCloudLogging.Test\Serilog.Sinks.GoogleCloudLogging.Test.csproj", "{858BBD6D-9FF4-4D78-95A7-7139E69FCC55}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.Sinks.GoogleCloudLogging.Benchmark", "Serilog.Sinks.GoogleCloudLogging.Benchmark\Serilog.Sinks.GoogleCloudLogging.Benchmark.csproj", "{FD57E195-5EDD-42B5-A722-4043636AA032}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{858BBD6D-9FF4-4D78-95A7-7139E69FCC55}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{858BBD6D-9FF4-4D78-95A7-7139E69FCC55}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{858BBD6D-9FF4-4D78-95A7-7139E69FCC55}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FD57E195-5EDD-42B5-A722-4043636AA032}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FD57E195-5EDD-42B5-A722-4043636AA032}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FD57E195-5EDD-42B5-A722-4043636AA032}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FD57E195-5EDD-42B5-A722-4043636AA032}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSink.cs
+++ b/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSink.cs
@@ -104,6 +104,18 @@ public class GoogleCloudLoggingSink : IBatchedLogEventSink
             HandleSpecialProperty(log, property.Key, property.Value);
         }
 
+        if (_sinkOptions.UseLogCorrelation)
+        {
+            if (evnt.TraceId.ToString() is { Length: > 0 } traceId)
+            {
+                log.Trace = $"projects/{_projectId}/traces/{traceId}";
+            }
+            if (evnt.SpanId?.ToString() is { Length: > 0 } spanId)
+            {
+                log.SpanId = spanId;
+            }
+        }
+
         if (_serviceContext != null)
             jsonPayload.Fields.Add("serviceContext", Value.ForStruct(_serviceContext));
 
@@ -119,12 +131,6 @@ public class GoogleCloudLoggingSink : IBatchedLogEventSink
 
         if (_sinkOptions.UseLogCorrelation)
         {
-            if (key.Equals("TraceId", StringComparison.OrdinalIgnoreCase))
-                log.Trace = $"projects/{_projectId}/traces/{GetString(value)}";
-
-            if (key.Equals("SpanId", StringComparison.OrdinalIgnoreCase))
-                log.SpanId = GetString(value);
-
             if (key.Equals("TraceSampled", StringComparison.OrdinalIgnoreCase))
                 log.TraceSampled = GetBoolean(value);
         }

--- a/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSink.cs
+++ b/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSink.cs
@@ -8,9 +8,9 @@ using Google.Api.Gax.Grpc;
 using Google.Cloud.Logging.Type;
 using Google.Cloud.Logging.V2;
 using Google.Protobuf.WellKnownTypes;
+using Serilog.Core;
 using Serilog.Events;
 using Serilog.Formatting;
-using Serilog.Sinks.PeriodicBatching;
 
 namespace Serilog.Sinks.GoogleCloudLogging;
 
@@ -62,7 +62,7 @@ public class GoogleCloudLoggingSink : IBatchedLogEventSink
             : new LoggingServiceV2ClientBuilder { JsonCredentials = _sinkOptions.GoogleCredentialJson }.Build();
     }
 
-    public Task EmitBatchAsync(IEnumerable<LogEvent> events)
+    public Task EmitBatchAsync(IReadOnlyCollection<LogEvent> events)
     {
         using var writer = new StringWriter();
         var entries = new List<LogEntry>();

--- a/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSink.cs
+++ b/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSink.cs
@@ -64,15 +64,18 @@ public sealed class GoogleCloudLoggingSink : IBatchedLogEventSink
         // logging client for google cloud apis
         _client = _sinkOptions.GoogleCredentialJson.IsNullOrWhiteSpace()
             ? LoggingServiceV2Client.Create()
-            : new LoggingServiceV2ClientBuilder { JsonCredentials = _sinkOptions.GoogleCredentialJson }.Build();
+            : new LoggingServiceV2ClientBuilder { GoogleCredential = Google.Apis.Auth.OAuth2.CredentialFactory.FromJson<Google.Apis.Auth.OAuth2.GoogleCredential>(_sinkOptions.GoogleCredentialJson) }.Build();
     }
 
     //For testing and benchmarking purposes
     internal GoogleCloudLoggingSink(string projectId, ITextFormatter? textFormatter)
     {
         _projectId = projectId;
-        _logFormatter = new LogFormatter(textFormatter);;
+        _logFormatter = new LogFormatter(textFormatter);
         _sinkOptions = new GoogleCloudLoggingSinkOptions(projectId, useLogCorrelation: true);
+        _client = null!;
+        _resource = null!;
+        _logName = null!;
     }
 
     internal List<LogEntry> CreateEventsBatch(IReadOnlyCollection<LogEvent> events)
@@ -138,6 +141,19 @@ public sealed class GoogleCloudLoggingSink : IBatchedLogEventSink
 
         if (_serviceContext != null)
             jsonPayload.Fields.Add("serviceContext", Value.ForStruct(_serviceContext));
+
+        // format exception for Google Cloud Error Reporting
+        // see: https://cloud.google.com/error-reporting/docs/formatting-error-messages
+        if (evnt.Exception != null)
+        {
+            //uses exception property to use the same convention as the official NLog implementation target
+            jsonPayload.Fields.Add("exception", Value.ForString(evnt.Exception.ToString()));
+        }
+        else if (evnt.Level >= LogEventLevel.Error)
+        {
+            //To log an error event that is a text message
+            jsonPayload.Fields.Add("@type", Value.ForString("type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent"));
+        }
 
         log.JsonPayload = jsonPayload;
 

--- a/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSink.cs
+++ b/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSink.cs
@@ -15,7 +15,7 @@ using Serilog.Formatting;
 
 namespace Serilog.Sinks.GoogleCloudLogging;
 
-public class GoogleCloudLoggingSink : IBatchedLogEventSink
+public sealed class GoogleCloudLoggingSink : IBatchedLogEventSink
 {
     private readonly GoogleCloudLoggingSinkOptions _sinkOptions;
     private readonly LoggingServiceV2Client _client;
@@ -67,7 +67,15 @@ public class GoogleCloudLoggingSink : IBatchedLogEventSink
             : new LoggingServiceV2ClientBuilder { JsonCredentials = _sinkOptions.GoogleCredentialJson }.Build();
     }
 
-    private List<LogEntry> CreateEventsBatch(IReadOnlyCollection<LogEvent> events)
+    //For testing and benchmarking purposes
+    internal GoogleCloudLoggingSink(string projectId, ITextFormatter? textFormatter)
+    {
+        _projectId = projectId;
+        _logFormatter = new LogFormatter(textFormatter);;
+        _sinkOptions = new GoogleCloudLoggingSinkOptions(projectId, useLogCorrelation: true);
+    }
+
+    internal List<LogEntry> CreateEventsBatch(IReadOnlyCollection<LogEvent> events)
     {
         //writer is used for message template rendering
         using var writer = new StringWriter(_stringBuilder);

--- a/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSink.cs
+++ b/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSink.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Google.Api;
@@ -24,6 +25,10 @@ public class GoogleCloudLoggingSink : IBatchedLogEventSink
     private readonly LogFormatter _logFormatter;
     private readonly Struct? _serviceContext;
 
+    /// <summary>
+    /// Because batches aren't executed concurrently, we can reuse the stringBuilder
+    /// </summary>
+    private readonly StringBuilder _stringBuilder = new StringBuilder();
 
     public GoogleCloudLoggingSink(GoogleCloudLoggingSinkOptions sinkOptions, ITextFormatter? textFormatter)
     {
@@ -62,10 +67,11 @@ public class GoogleCloudLoggingSink : IBatchedLogEventSink
             : new LoggingServiceV2ClientBuilder { JsonCredentials = _sinkOptions.GoogleCredentialJson }.Build();
     }
 
-    public Task EmitBatchAsync(IReadOnlyCollection<LogEvent> events)
+    private List<LogEntry> CreateEventsBatch(IReadOnlyCollection<LogEvent> events)
     {
-        using var writer = new StringWriter();
-        var entries = new List<LogEntry>();
+        //writer is used for message template rendering
+        using var writer = new StringWriter(_stringBuilder);
+        var entries = new List<LogEntry>(events.Count);
 
         foreach (var evnt in events)
         {
@@ -79,6 +85,12 @@ public class GoogleCloudLoggingSink : IBatchedLogEventSink
                 Debugging.SelfLog.WriteLine("Log entry is too large for Google Cloud Logging: {0}", GetLogEntryMessage(logEntry));
         }
 
+        return entries;
+    }
+
+    public Task EmitBatchAsync(IReadOnlyCollection<LogEvent> events)
+    {
+        var entries = CreateEventsBatch(events);
         return entries.Count > 0
             ? _client.WriteLogEntriesAsync(_logName, _resource, _sinkOptions.Labels, entries, CancellationToken.None)
             : Task.CompletedTask;

--- a/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSinkExtensions.cs
+++ b/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSinkExtensions.cs
@@ -5,7 +5,6 @@ using Serilog.Core;
 using Serilog.Events;
 using Serilog.Formatting;
 using Serilog.Formatting.Display;
-using Serilog.Sinks.PeriodicBatching;
 
 namespace Serilog.Sinks.GoogleCloudLogging;
 
@@ -39,17 +38,16 @@ public static class GoogleCloudLoggingSinkExtensions
         // formatter can be null if neither parameters are provided
         textFormatter ??= !String.IsNullOrWhiteSpace(outputTemplate) ? new MessageTemplateTextFormatter(outputTemplate) : null;
 
-        var batchingOptions = new PeriodicBatchingSinkOptions
+        var batchingOptions = new BatchingOptions
         {
             BatchSizeLimit = batchSizeLimit ?? 100,
-            Period = period ?? TimeSpan.FromSeconds(5),
+            BufferingTimeLimit = period ?? TimeSpan.FromSeconds(5),
             QueueLimit = queueLimit
         };
 
         var sink = new GoogleCloudLoggingSink(sinkOptions, textFormatter);
-        var batchingSink = new PeriodicBatchingSink(sink, batchingOptions);
 
-        return loggerConfiguration.Sink(batchingSink, restrictedToMinimumLevel, levelSwitch);
+        return loggerConfiguration.Sink(sink, batchingOptions, restrictedToMinimumLevel, levelSwitch);
     }
 
     /// <summary>

--- a/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSinkExtensions.cs
+++ b/src/Serilog.Sinks.GoogleCloudLogging/GoogleCloudLoggingSinkExtensions.cs
@@ -36,7 +36,7 @@ public static class GoogleCloudLoggingSinkExtensions
     {
         // use provided text formatter or create one from output template 
         // formatter can be null if neither parameters are provided
-        textFormatter ??= !String.IsNullOrWhiteSpace(outputTemplate) ? new MessageTemplateTextFormatter(outputTemplate) : null;
+        textFormatter ??= !String.IsNullOrWhiteSpace(outputTemplate) ? new MessageTemplateTextFormatter(outputTemplate!) : null;
 
         var batchingOptions = new BatchingOptions
         {

--- a/src/Serilog.Sinks.GoogleCloudLogging/LogFormatter.cs
+++ b/src/Serilog.Sinks.GoogleCloudLogging/LogFormatter.cs
@@ -116,7 +116,7 @@ internal class LogFormatter
             // limited to 512 characters and must be url-encoded (using 500 char limit here to be safe)
             var safeChars = LogNameUnsafeChars.Replace(name, "");
             var truncated = safeChars.Length > 500 ? safeChars.Substring(0, 500) : safeChars;
-            var encoded = UrlEncoder.Default.Encode(safeChars);
+            var encoded = UrlEncoder.Default.Encode(truncated);
 
             // LogName class creates templated string matching GCP requirements
             logName = new LogName(projectId, encoded).ToString();

--- a/src/Serilog.Sinks.GoogleCloudLogging/LogFormatter.cs
+++ b/src/Serilog.Sinks.GoogleCloudLogging/LogFormatter.cs
@@ -50,7 +50,8 @@ internal partial class LogFormatter
                 if (writer.GetStringBuilder().Length > 0)
                     writer.WriteLine();
 
-                writer.Write(e.Exception.ToString());
+                //Exception message stacktrace goes as a separate exception property
+                writer.Write(e.Exception.Message);
             }
         }
 

--- a/src/Serilog.Sinks.GoogleCloudLogging/Serilog.Sinks.GoogleCloudLogging.csproj
+++ b/src/Serilog.Sinks.GoogleCloudLogging/Serilog.Sinks.GoogleCloudLogging.csproj
@@ -18,7 +18,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <TargetFrameworks>net6.0;net5.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;netstandard2.1</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -29,14 +29,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Logging.V2" Version="4.0.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+    <PackageReference Include="Google.Cloud.Logging.V2" Version="4.4.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Serilog" Version="2.11.0" />
-    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.3.1" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
+    <PackageReference Include="Serilog" Version="4.0.0" />
+    <PackageReference Condition="'$(TargetFramework)' == 'net6.0'" Include="System.Text.Encodings.Web" Version="6.0.0" />
+    <PackageReference Condition="'$(TargetFramework)' != 'net6.0'" Include="System.Text.Encodings.Web" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Serilog.Sinks.GoogleCloudLogging/Serilog.Sinks.GoogleCloudLogging.csproj
+++ b/src/Serilog.Sinks.GoogleCloudLogging/Serilog.Sinks.GoogleCloudLogging.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <PackageVersion>6.0.0-alpha.5</PackageVersion>
+    <PackageVersion>6.0.0-alpha.6</PackageVersion>
     <Description>Serilog sink that writes events to Google Cloud Platform (Stackdriver) Logging.</Description>
     <Authors>Mani Gandham</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -18,7 +18,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <TargetFrameworks>net8.0;net9.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -29,14 +29,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Logging.V2" Version="4.4.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
+    <PackageReference Include="Google.Cloud.Logging.V2" Version="4.5.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Serilog" Version="4.0.0" />
-    <PackageReference Condition="'$(TargetFramework)' == 'net9.0'" Include="System.Text.Encodings.Web" Version="9.0.0" />
-    <PackageReference Condition="'$(TargetFramework)' != 'net9.0'" Include="System.Text.Encodings.Web" Version="8.0.0" />
+    <PackageReference Include="Serilog" Version="4.3.1" />
+    <PackageReference Condition="'$(TargetFramework)' == 'net10.0'" Include="System.Text.Encodings.Web" Version="10.0.5" />
+    <PackageReference Condition="'$(TargetFramework)' == 'net9.0'" Include="System.Text.Encodings.Web" Version="9.0.14" />
+    <PackageReference Condition="'$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'netstandard2.0'" Include="System.Text.Encodings.Web" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">

--- a/src/Serilog.Sinks.GoogleCloudLogging/Serilog.Sinks.GoogleCloudLogging.csproj
+++ b/src/Serilog.Sinks.GoogleCloudLogging/Serilog.Sinks.GoogleCloudLogging.csproj
@@ -38,5 +38,10 @@
     <PackageReference Condition="'$(TargetFramework)' == 'net9.0'" Include="System.Text.Encodings.Web" Version="9.0.0" />
     <PackageReference Condition="'$(TargetFramework)' != 'net9.0'" Include="System.Text.Encodings.Web" Version="8.0.0" />
   </ItemGroup>
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>Serilog.Sinks.GoogleCloudLogging.Benchmark</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
 
 </Project>

--- a/src/Serilog.Sinks.GoogleCloudLogging/Serilog.Sinks.GoogleCloudLogging.csproj
+++ b/src/Serilog.Sinks.GoogleCloudLogging/Serilog.Sinks.GoogleCloudLogging.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <PackageVersion>5.0.0</PackageVersion>
+    <PackageVersion>6.0.0-alpha.5</PackageVersion>
     <Description>Serilog sink that writes events to Google Cloud Platform (Stackdriver) Logging.</Description>
     <Authors>Mani Gandham</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -18,7 +18,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <TargetFrameworks>net8.0;net6.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -35,8 +35,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Serilog" Version="4.0.0" />
-    <PackageReference Condition="'$(TargetFramework)' == 'net6.0'" Include="System.Text.Encodings.Web" Version="6.0.0" />
-    <PackageReference Condition="'$(TargetFramework)' != 'net6.0'" Include="System.Text.Encodings.Web" Version="8.0.0" />
+    <PackageReference Condition="'$(TargetFramework)' == 'net9.0'" Include="System.Text.Encodings.Web" Version="9.0.0" />
+    <PackageReference Condition="'$(TargetFramework)' != 'net9.0'" Include="System.Text.Encodings.Web" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/TestWeb/TestWeb.csproj
+++ b/src/TestWeb/TestWeb.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>default</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.11.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
+    <PackageReference Include="Serilog" Version="4.0.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TestWeb/TestWeb.csproj
+++ b/src/TestWeb/TestWeb.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>default</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="4.0.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.0" />
+    <PackageReference Include="Serilog" Version="4.3.1" />
+    <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Dear Mani,

Please review this pull request.

Summary:

1. Upgrades Serilog to 4.0
2. Adds .NET 8.0 and removes .NET 5.0 from Target Frameworks
3. Adds source-generated Regex support for .NET 8.0 + to `LogFormatter`
4. Uses introduced in Serilog 3.1 properties TraceId/SpanId to propagate trace context

Please let me know if you see that the PR could be improved.

Thank you.